### PR TITLE
add: proper executable

### DIFF
--- a/jaksel-interpreter.js
+++ b/jaksel-interpreter.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const fs = require('fs');
 
 const inputFile = () => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "jaksel-language",
+  "version": "1.0.0",
+  "description": "Jaksel programming language",
+  "main": "jaksel-interpreter.js",
+  "bin": {
+   "jaksel": "./jaksel-interpreter.js"
+  },
+  "directories": {
+    "example": "example"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RioChndr/jaksel-language.git"
+  },
+  "author": "Rio Chandra",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/RioChndr/jaksel-language/issues"
+  },
+  "homepage": "https://github.com/RioChndr/jaksel-language#readme"
+}


### PR DESCRIPTION
Closes #12 

This pull request contains a feature that can run on the command line when you run `jaksel <filename>`. Just run the npm install command at the root of the project as a global package.
```sh
npm i -g .
```

And to remove just run this command

```sh
npm rm -g jaksel-language
```