### PR TITLE
fix/better call argument with string literal

### DIFF
--- a/example/example-function.jaksel
+++ b/example/example-function.jaksel
@@ -18,9 +18,9 @@ so about fungsi_param a
 thats it sih
 
 so about fungsiMultiParam a b c
-    spill "a: " + a
-    spill "b: " + b
-    spill "c: " + c
+    spill "argumen pertama: " + a
+    spill "argumen kedua: " + b
+    spill "argumen ketiga: " + c
 thats it sih
 
 call my_story
@@ -34,6 +34,9 @@ literally nama itu "adi"
 call fungsi_param nama
 spill "\n"
 
+call fungsi_param "Rayhan"
+spill "\n"
+
 call fungsi_param 3
 spill "\n"
 
@@ -42,5 +45,5 @@ spill "\n"
 
 literally nama2 itu "budi"
 
-call fungsiMultiParam nama nama2 4
+call fungsiMultiParam 2 nama2 "and then Romeo says \"I love you\" to Juliet"
 spill "\n"

--- a/lib/logics/parser/functionCall.js
+++ b/lib/logics/parser/functionCall.js
@@ -7,7 +7,7 @@ const functionCall = (msg) => {
   if (!match) return null;
 
   const [, funcName, argValues = ''] = match;
-  console.log(argValues);
+
   /**
    * if function doesn't have arguments
    */

--- a/lib/logics/parser/functionCall.js
+++ b/lib/logics/parser/functionCall.js
@@ -2,31 +2,37 @@
  * @param msg {string}
  */
 const functionCall = (msg) => {
-  let format = /call (\w+)((\s\w+)*)?/;
+  let format = /call (\w+)((\s(\w+|\".*\"))*)/;
   let match = msg.match(format);
   if (!match) return null;
 
-  const [, funcName, paramValues] = match;
+  const [, funcName, argValues = ''] = match;
+  console.log(argValues);
+  /**
+   * if function doesn't have arguments
+   */
+  if (argValues.trim() === '') {
+    return {
+      exp: `${funcName}();`
+    }
+  }
+  
+  /**
+   * Match arg1, arg2, ..., argN on function call.
+   * Argument can be variable, string literal, native boolean literal (true and false), or number.
+   * e.g:
+   * call helloFunction "a string literal" aVariable 4
+   * 
+   * we can even have string literal with escaped quotes
+   * e.g:
+   * call tellNextStory "and then Romeo says \"I love you\" to Juliet"
+   */
+  let paramFormat = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|[^\s]+/g;
+  let params = argValues.trim().match(paramFormat);
 
-  
-  
   return {
-    exp: `${funcName}(${paramsStringified(paramValues) || ifItisAString(msg)});`
+    exp: `${funcName}(${params.join()});`
   }
 };
-
-const paramsStringified = (paramValues)=>{
-  return (paramValues?.trim().split(/\s+/) ?? []).reduce((p, c, idx, arr) => idx !== arr.length - 1 ? `${p} ${c},` : `${p} ${c}`,'').trim() 
-  
-}
-
-const ifItisAString = (msg)=>{
-  const cmnds = msg.split(" ")
-  var cmnd = ""
-  for (let index = 2; index < cmnds.length; index++) {
-    cmnd += `${cmnds[index]}, `
-  };
-  return msg.split(" ")[2]
-}
 
 module.exports = functionCall;


### PR DESCRIPTION
This PR should fix #41

This allows passing string into multi-parameter function

Suppose we have function that takes 3 parameters
```
so about fungsiMultiParam a b c
    spill "argumen pertama: " + a
    spill "argumen kedua: " + b
    spill "argumen ketiga: " + c
thats it sih
```

when we call 
```
literally nama2 itu "budi"

call fungsiMultiParam 2 nama2 "hello world"
```

it should outputs
```sh
argumen pertama: 2
argumen kedua: budi
argumen ketiga: hello world
```

it also support escaping quotes inside string literal
```
literally nama2 itu "budi"

call fungsiMultiParam 3 nama2 "and then Romeo says \"I love you\" to Juliet"
```

it should outputs
```
argumen pertama: 2
argumen kedua: budi
argumen ketiga: and then Romeo says "I love you" to Juliet
```